### PR TITLE
Fix permanent hostname issue

### DIFF
--- a/chef-server/Dockerfile
+++ b/chef-server/Dockerfile
@@ -11,11 +11,6 @@ RUN	dpkg -i chef-server*.deb
 RUN	dpkg-divert --local --rename --add /sbin/initctl
 RUN	ln -sf /bin/true /sbin/initctl
 
-RUN	sysctl -w kernel.shmall=4194304 && sysctl -w kernel.shmmax=17179869184 && \
-	/opt/chef-server/embedded/bin/runsvdir-start & \
-	chef-server-ctl reconfigure && \
-	chef-server-ctl stop
-
 ADD	. /usr/local/bin/
 CMD	["run_chef_server"]
 

--- a/chef-server/run_chef_server
+++ b/chef-server/run_chef_server
@@ -2,5 +2,11 @@
 set -x
 sysctl -w kernel.shmmax=17179869184 # for postgres
 /opt/chef-server/embedded/bin/runsvdir-start &
+
+if [ x"$(hostname)" != x"$(grep server_name /etc/chef-server/chef-server-running.json | sed 's/.*\"\(.*\)\".*\"\(.*\)\".*/\2/')" ]; then
+	echo "Hostname changed, chef-server must be reconfigured"
+	chef-server-ctl reconfigure
+fi
+
 tail -F /opt/chef-server/embedded/service/*/log/current
 


### PR DESCRIPTION
Chef server can not function properly with incorect hostname.
Docker allows to override hostname on docker run -h <new_hostname> but chef server need to be reconfigured if hostname changed.

This commit introduce changes in startup script that will check current hostname and reconfigure chef-server if hostname changed.
Because deafult hostname empty - startup script will trigger reconfiguration on docker run anyway so doing this during docker build not required any more.

P.S. it was also hanging up on docker build for me, at reconfiguration step.
