### PR TITLE
Added --privileged to README for chef-server

### DIFF
--- a/chef-server/README.md
+++ b/chef-server/README.md
@@ -2,5 +2,5 @@ chef-server
 ===========
 
 ```sh
-$ docker run -d -p 443:443 base/chef-server
+$ docker run -d --privileged -p 443:443 base/chef-server
 ```


### PR DESCRIPTION
As docker won't allow you to use sysctl otherwise
